### PR TITLE
미션 진행도 조회, 보상 수령 기능 구현

### DIFF
--- a/src/main/java/com/mju/mentoring/member/application/auth/AuthService.java
+++ b/src/main/java/com/mju/mentoring/member/application/auth/AuthService.java
@@ -24,7 +24,7 @@ public class AuthService {
     @Transactional
     public void signup(final SignupRequest request) {
         memberService.checkDuplicate(request.username(), request.nickname());
-        Member member = Member.of(request.username(), request.password(), request.nickname());
+        Member member = Member.createDefault(request.username(), request.password(), request.nickname());
         memberRepository.save(member);
     }
 

--- a/src/main/java/com/mju/mentoring/member/application/member/MemberEventHandler.java
+++ b/src/main/java/com/mju/mentoring/member/application/member/MemberEventHandler.java
@@ -1,0 +1,24 @@
+package com.mju.mentoring.member.application.member;
+
+import com.mju.mentoring.mission.domain.progress.RewardReceivedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MemberEventHandler {
+
+    private final MemberService memberService;
+
+    @TransactionalEventListener(
+        classes = RewardReceivedEvent.class,
+        phase = TransactionPhase.AFTER_COMMIT
+    )
+    @Async
+    public void receiveReward(final RewardReceivedEvent event) {
+        memberService.increasePoint(event.getChallengerId(), event.getReward());
+    }
+}

--- a/src/main/java/com/mju/mentoring/member/application/member/MemberService.java
+++ b/src/main/java/com/mju/mentoring/member/application/member/MemberService.java
@@ -46,4 +46,10 @@ public class MemberService {
             throw new DuplicateNicknameException();
         }
     }
+
+    @Transactional
+    public void increasePoint(final Long userId, final Long point) {
+        Member member = findMemberById(userId);
+        member.increasePoint(point);
+    }
 }

--- a/src/main/java/com/mju/mentoring/member/config/AuthConfig.java
+++ b/src/main/java/com/mju/mentoring/member/config/AuthConfig.java
@@ -19,6 +19,7 @@ public class AuthConfig implements WebMvcConfigurer {
     private static final String ALL_URL_PATTERN = "/**";
     private static final String AUTH_URL_PATTERN = "/auth/**";
     private static final String BOARD_URL_PATTERN = "/boards/**";
+    private static final String PROGRESS_URL_PATTERN = "/progress/**";
 
     private final AuthArgumentResolver authArgumentResolver;
     private final AuthCheckInterceptor authCheckInterceptor;
@@ -38,6 +39,7 @@ public class AuthConfig implements WebMvcConfigurer {
         PathMatcherInterceptor interceptor = PathMatcherInterceptor.from(authCheckInterceptor);
         return interceptor.excludePathPattern(ALL_URL_PATTERN, HttpMethod.OPTION)
             .excludePathPattern(AUTH_URL_PATTERN, HttpMethod.ANY)
-            .excludePathPattern(BOARD_URL_PATTERN, HttpMethod.GET);
+            .excludePathPattern(BOARD_URL_PATTERN, HttpMethod.GET)
+            .includePathPattern(PROGRESS_URL_PATTERN, HttpMethod.GET);
     }
 }

--- a/src/main/java/com/mju/mentoring/member/domain/Member.java
+++ b/src/main/java/com/mju/mentoring/member/domain/Member.java
@@ -22,21 +22,33 @@ public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
     @Embedded
-    AuthInformation authInformation;
+    private AuthInformation authInformation;
 
     @Column(unique = true, nullable = false)
-    String nickname;
+    private String nickname;
 
-    private Member(final AuthInformation authInformation, final String nickname) {
+    @Embedded
+    private Point point;
+
+    private Member(
+        final AuthInformation authInformation, final String nickname, final Point point) {
         this.authInformation = authInformation;
         this.nickname = nickname;
+        this.point = point;
     }
 
-    public static Member of(final String username, final String password, final String nickname) {
-        return new Member(AuthInformation.of(username, password), nickname);
+    public static Member createDefault(
+        final String username, final String password, final String nickname) {
+        return new Member(AuthInformation.of(username, password), nickname, Point.createDefault());
+    }
+
+    public static Member of(
+        final String username, final String password, final String nickname, final Long point
+    ) {
+        return new Member(AuthInformation.of(username, password), nickname, Point.from(point));
     }
 
     public boolean isValidPassword(final String password) {
@@ -45,6 +57,10 @@ public class Member extends BaseEntity {
 
     public void changeNickName(final String newNickname) {
         this.nickname = newNickname;
+    }
+
+    public void increasePoint(final Long plusPoint) {
+        point.increasePoint(plusPoint);
     }
 
     public String getUsername() {

--- a/src/main/java/com/mju/mentoring/member/domain/Point.java
+++ b/src/main/java/com/mju/mentoring/member/domain/Point.java
@@ -1,0 +1,30 @@
+package com.mju.mentoring.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Point {
+
+    @Column
+    private Long point;
+
+    public static Point createDefault() {
+        return new Point(0L);
+    }
+
+    public static Point from(final Long point) {
+        return new Point(point);
+    }
+
+    public void increasePoint(final Long plusPoint) {
+        point += plusPoint;
+    }
+}

--- a/src/main/java/com/mju/mentoring/member/exception/MemberExceptionHandler.java
+++ b/src/main/java/com/mju/mentoring/member/exception/MemberExceptionHandler.java
@@ -28,7 +28,7 @@ public class MemberExceptionHandler {
 
     @ExceptionHandler(MemberNotFoundException.class)
     public ResponseEntity<String> handleMemberNotFoundException(
-        final DuplicateNicknameException exception) {
+        final MemberNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 

--- a/src/main/java/com/mju/mentoring/mission/application/mission/MissionService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/mission/MissionService.java
@@ -21,6 +21,7 @@ public class MissionService {
         return missionRepository.findAll();
     }
 
+    @Transactional
     public void challengeMission(final Long challengerId, final Long missionId) {
         missionRepository.findById(missionId)
             .ifPresentOrElse(mission -> Events.raise(

--- a/src/main/java/com/mju/mentoring/mission/application/mission/MissionService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/mission/MissionService.java
@@ -24,7 +24,8 @@ public class MissionService {
     public void challengeMission(final Long challengerId, final Long missionId) {
         missionRepository.findById(missionId)
             .ifPresentOrElse(mission -> Events.raise(
-                    new ChallengedMissionEvent(challengerId, missionId, mission.getGoal())),
+                    new ChallengedMissionEvent(
+                        challengerId, missionId, mission.getGoal(), mission.getReward())),
                 () -> {
                     throw new NotFoundMissionException(missionId);
                 });

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressEventHandler.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressEventHandler.java
@@ -18,7 +18,7 @@ public class ProgressEventHandler {
     @EventListener
     public void challengeMission(final ChallengedMissionEvent event) {
         progressService.challengeMission(
-            event.getChallengerId(), event.getMissionId(), event.getGoal());
+            event.getChallengerId(), event.getMissionId(), event.getReward(), event.getGoal());
     }
 
     @TransactionalEventListener(

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -5,6 +5,8 @@ import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import java.util.List;
@@ -35,8 +37,10 @@ public class ProgressService {
             challengerId, getOperateType, resourceType).ifPresent(MissionProgress::increaseCount);
     }
 
-    public List<ProgressResponse> findAll() {
-        List<CurrentProgress> progress = missionProgressRepository.findAll();
+    public List<ProgressResponse> findAll(
+        final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
+        List<CurrentProgress> progress = missionProgressRepository.findAll(
+            progressStatus, rewardStatus);
         return progress.stream()
             .map(CurrentProgress::toResponse)
             .toList();

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -2,23 +2,26 @@ package com.mju.mentoring.mission.application.progress;
 
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
+import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
-import java.util.Optional;
+import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ProgressService {
 
     private final MissionProgressRepository missionProgressRepository;
 
     @Transactional
     public void challengeMission(final Long challengerId, final Long missionId, final Long goal) {
-        if(missionProgressRepository.hasChallengedMission(challengerId, missionId)){
+        if (missionProgressRepository.hasChallengedMission(challengerId, missionId)) {
             throw new AlreadyChallengeMission();
         }
 
@@ -30,5 +33,12 @@ public class ProgressService {
         final ResourceType resourceType) {
         missionProgressRepository.findByChallengeIdAndType(
             challengerId, getOperateType, resourceType).ifPresent(MissionProgress::increaseCount);
+    }
+
+    public List<ProgressResponse> findAll() {
+        List<CurrentProgress> progress = missionProgressRepository.findAll();
+        return progress.stream()
+            .map(CurrentProgress::toResponse)
+            .toList();
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -22,12 +22,13 @@ public class ProgressService {
     private final MissionProgressRepository missionProgressRepository;
 
     @Transactional
-    public void challengeMission(final Long challengerId, final Long missionId, final Long goal) {
+    public void challengeMission(
+        final Long challengerId, final Long missionId, final Long reward, final Long goal) {
         if (missionProgressRepository.hasChallengedMission(challengerId, missionId)) {
             throw new AlreadyChallengeMission();
         }
 
-        missionProgressRepository.save(MissionProgress.of(goal, missionId, challengerId));
+        missionProgressRepository.save(MissionProgress.of(goal, missionId, reward, challengerId));
     }
 
     @Transactional

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -10,6 +10,7 @@ import com.mju.mentoring.mission.domain.progress.ProgressStatus;
 import com.mju.mentoring.mission.domain.progress.RewardReceivedEvent;
 import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
+import com.mju.mentoring.mission.exception.exceptions.InvalidChallengerException;
 import com.mju.mentoring.mission.exception.exceptions.NoCompletedProgressException;
 import com.mju.mentoring.mission.exception.exceptions.NotFoundProgressException;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
@@ -42,18 +43,18 @@ public class ProgressService {
             challengerId, getOperateType, resourceType).ifPresent(MissionProgress::increaseCount);
     }
 
-    public List<ProgressResponse> findAll(
+    public List<ProgressResponse> findAll(final Long challengerId,
         final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
         List<CurrentProgress> progress = missionProgressRepository.findAll(
-            progressStatus, rewardStatus);
+            challengerId, progressStatus, rewardStatus);
         return progress.stream()
             .map(CurrentProgress::toResponse)
             .toList();
     }
 
     @Transactional
-    public void receiveReward(final Long id) {
-        MissionProgress progress = findById(id);
+    public void receiveReward(final Long challengerId, final Long id) {
+        MissionProgress progress = findById(challengerId, id);
         progress.receiveReward();
         raiseRewardReceivedEvent(progress);
     }

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -10,6 +10,7 @@ import com.mju.mentoring.mission.domain.progress.ProgressStatus;
 import com.mju.mentoring.mission.domain.progress.RewardReceivedEvent;
 import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
+import com.mju.mentoring.mission.exception.exceptions.NoCompletedProgressException;
 import com.mju.mentoring.mission.exception.exceptions.NotFoundProgressException;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import java.util.List;
@@ -58,9 +59,12 @@ public class ProgressService {
     }
 
     @Transactional
-    public void receiveALlRewards(final Long challengerId) {
+    public void receiveAllRewards(final Long challengerId) {
         List<MissionProgress> progress = missionProgressRepository.findRewardWaitingProgress(
             challengerId);
+        if (progress.isEmpty()) {
+            throw new NoCompletedProgressException();
+        }
         progress.forEach(MissionProgress::receiveReward);
         progress.forEach(this::raiseRewardReceivedEvent);
     }

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -8,6 +8,7 @@ import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
 import com.mju.mentoring.mission.domain.progress.ProgressStatus;
 import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
+import com.mju.mentoring.mission.exception.exceptions.NotFoundProgressException;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -45,5 +46,16 @@ public class ProgressService {
         return progress.stream()
             .map(CurrentProgress::toResponse)
             .toList();
+    }
+
+    @Transactional
+    public void receiveReward(final Long id) {
+        MissionProgress progress = findById(id);
+        progress.receiveReward();
+    }
+
+    private MissionProgress findById(final Long id) {
+        return missionProgressRepository.findById(id)
+            .orElseThrow(() -> new NotFoundProgressException(id));
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -54,6 +54,13 @@ public class ProgressService {
         progress.receiveReward();
     }
 
+    @Transactional
+    public void receiveALlRewards(final Long challengerId) {
+        List<MissionProgress> progress = missionProgressRepository.findRewardWaitingProgress(
+            challengerId);
+        progress.forEach(MissionProgress::receiveReward);
+    }
+
     private MissionProgress findById(final Long id) {
         return missionProgressRepository.findById(id)
             .orElseThrow(() -> new NotFoundProgressException(id));

--- a/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/ProgressService.java
@@ -69,9 +69,13 @@ public class ProgressService {
         progress.forEach(this::raiseRewardReceivedEvent);
     }
 
-    private MissionProgress findById(final Long id) {
-        return missionProgressRepository.findById(id)
+    private MissionProgress findById(final Long challengerId, final Long id) {
+        MissionProgress progress = missionProgressRepository.findById(id)
             .orElseThrow(() -> new NotFoundProgressException(id));
+        if (!progress.getChallengerId().equals(challengerId)) {
+            throw new InvalidChallengerException();
+        }
+        return progress;
     }
 
     private void raiseRewardReceivedEvent(final MissionProgress progress) {

--- a/src/main/java/com/mju/mentoring/mission/application/progress/dto/ProgressResponse.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/dto/ProgressResponse.java
@@ -1,5 +1,9 @@
 package com.mju.mentoring.mission.application.progress.dto;
 
-public record ProgressResponse(String missionTitle, Long currentCount, Long goal, Double progress) {
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
+
+public record ProgressResponse(String missionTitle, Long currentCount, Long goal, Double progress,
+                               ProgressStatus progressStatus, RewardStatus rewardStatus) {
 
 }

--- a/src/main/java/com/mju/mentoring/mission/application/progress/dto/ProgressResponse.java
+++ b/src/main/java/com/mju/mentoring/mission/application/progress/dto/ProgressResponse.java
@@ -1,0 +1,5 @@
+package com.mju.mentoring.mission.application.progress.dto;
+
+public record ProgressResponse(String missionTitle, Long currentCount, Long goal, Double progress) {
+
+}

--- a/src/main/java/com/mju/mentoring/mission/config/ConverterConfig.java
+++ b/src/main/java/com/mju/mentoring/mission/config/ConverterConfig.java
@@ -1,0 +1,17 @@
+package com.mju.mentoring.mission.config;
+
+import com.mju.mentoring.mission.ui.progress.helper.StringToProgressStatusConverter;
+import com.mju.mentoring.mission.ui.progress.helper.StringToRewardStatusConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ConverterConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToProgressStatusConverter());
+        registry.addConverter(new StringToRewardStatusConverter());
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/domain/mission/ChallengedMissionEvent.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/mission/ChallengedMissionEvent.java
@@ -12,4 +12,5 @@ public class ChallengedMissionEvent extends Event {
     private final Long challengerId;
     private final Long missionId;
     private final Long goal;
+    private final Long reward;
 }

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/CurrentInfo.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/CurrentInfo.java
@@ -37,7 +37,7 @@ public class CurrentInfo {
     }
 
     public boolean canReceiveReward() {
-        return rewardStatus.canReceive();
+        return progressInfo.isSatisfiedGoal() && rewardStatus.canReceive();
     }
 
     public void increaseCount() {

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/CurrentInfo.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/CurrentInfo.java
@@ -11,10 +11,12 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 @Embeddable

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgress.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgress.java
@@ -26,21 +26,26 @@ public class MissionProgress {
     private CurrentInfo currentInfo;
 
     @Column
+    private Long reward;
+
+    @Column
     private Long missionId;
 
     @Column
     private Long challengerId;
 
     private MissionProgress(final CurrentInfo currentInfo, final Long missionId,
-        final Long challengerId) {
+        final Long reward, final Long challengerId) {
         this.currentInfo = currentInfo;
         this.missionId = missionId;
+        this.reward = reward;
         this.challengerId = challengerId;
     }
 
     public static MissionProgress of(final Long goal, final Long missionId,
-        final Long challengerId) {
-        return new MissionProgress(CurrentInfo.initProgressInfo(goal), missionId, challengerId);
+        final Long reward, final Long challengerId) {
+        return new MissionProgress(CurrentInfo.initProgressInfo(goal), missionId,
+            reward, challengerId);
     }
 
     public void increaseCount() {

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
@@ -8,7 +8,8 @@ import java.util.Optional;
 
 public interface MissionProgressRepository {
 
-    List<CurrentProgress> findAll();
+    List<CurrentProgress> findAll(
+        final ProgressStatus progressStatus, final RewardStatus rewardStatus);
 
     Optional<MissionProgress> findById(final Long id);
 

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
@@ -2,9 +2,13 @@ package com.mju.mentoring.mission.domain.progress;
 
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
+import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
+import java.util.List;
 import java.util.Optional;
 
 public interface MissionProgressRepository {
+
+    List<CurrentProgress> findAll();
 
     Optional<MissionProgress> findById(final Long id);
 

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public interface MissionProgressRepository {
 
     List<CurrentProgress> findAll(
-        final ProgressStatus progressStatus, final RewardStatus rewardStatus);
+        final Long challengerId, final ProgressStatus progressStatus, final RewardStatus rewardStatus);
 
     Optional<MissionProgress> findById(final Long id);
 

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/MissionProgressRepository.java
@@ -22,4 +22,6 @@ public interface MissionProgressRepository {
         final OperateType getOperateType, final ResourceType resourceType);
 
     boolean hasChallengedMission(final Long challengerId, final Long missionId);
+
+    List<MissionProgress> findRewardWaitingProgress(Long challengerId);
 }

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/ProgressInfo.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/ProgressInfo.java
@@ -8,10 +8,12 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 @Embeddable

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/ProgressStatus.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/ProgressStatus.java
@@ -3,5 +3,4 @@ package com.mju.mentoring.mission.domain.progress;
 public enum ProgressStatus {
 
     IN_PROGRESS, COMPLETED;
-
 }

--- a/src/main/java/com/mju/mentoring/mission/domain/progress/RewardReceivedEvent.java
+++ b/src/main/java/com/mju/mentoring/mission/domain/progress/RewardReceivedEvent.java
@@ -1,0 +1,12 @@
+package com.mju.mentoring.mission.domain.progress;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RewardReceivedEvent {
+
+    private final Long challengerId;
+    private final Long reward;
+}

--- a/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
@@ -1,11 +1,12 @@
 package com.mju.mentoring.mission.exception;
 
 import com.mju.mentoring.mission.exception.exceptions.NotFoundMissionException;
+import com.mju.mentoring.mission.exception.exceptions.WrongProgressStatusException;
+import com.mju.mentoring.mission.exception.exceptions.WrongRewardStatusException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class MissionExceptionHandler {
@@ -16,9 +17,16 @@ public class MissionExceptionHandler {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
-    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<String> handleConversionFailedException(
-        final MethodArgumentTypeMismatchException exception
+    @ExceptionHandler(WrongProgressStatusException.class)
+    public ResponseEntity<String> handleWrongProgressStatusException(
+        final WrongProgressStatusException exception
+    ) {
+        return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
+    }
+
+    @ExceptionHandler(WrongRewardStatusException.class)
+    public ResponseEntity<String> handleWrongRewardStatusException(
+        final WrongRewardStatusException exception
     ) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }

--- a/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.mju.mentoring.mission.exception;
 
+import com.mju.mentoring.mission.exception.exceptions.InvalidChallengerException;
 import com.mju.mentoring.mission.exception.exceptions.NoCompletedProgressException;
 import com.mju.mentoring.mission.exception.exceptions.NotFoundMissionException;
 import com.mju.mentoring.mission.exception.exceptions.WrongProgressStatusException;

--- a/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
@@ -39,6 +39,13 @@ public class MissionExceptionHandler {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 
+    @ExceptionHandler
+    public ResponseEntity<String> handleInvalidChallengerException(
+        final InvalidChallengerException exception
+    ) {
+        return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
+    }
+
     private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
         final Exception exception) {
         return ResponseEntity.status(httpStatus)

--- a/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @RestControllerAdvice
 public class MissionExceptionHandler {
@@ -15,8 +16,15 @@ public class MissionExceptionHandler {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<String> handleConversionFailedException(
+        final MethodArgumentTypeMismatchException exception
+    ) {
+        return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
+    }
+
     private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
-        final NotFoundMissionException exception) {
+        final Exception exception) {
         return ResponseEntity.status(httpStatus)
             .body(exception.getMessage());
     }

--- a/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/MissionExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.mju.mentoring.mission.exception;
 
+import com.mju.mentoring.mission.exception.exceptions.NoCompletedProgressException;
 import com.mju.mentoring.mission.exception.exceptions.NotFoundMissionException;
 import com.mju.mentoring.mission.exception.exceptions.WrongProgressStatusException;
 import com.mju.mentoring.mission.exception.exceptions.WrongRewardStatusException;
@@ -27,6 +28,13 @@ public class MissionExceptionHandler {
     @ExceptionHandler(WrongRewardStatusException.class)
     public ResponseEntity<String> handleWrongRewardStatusException(
         final WrongRewardStatusException exception
+    ) {
+        return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleNoCompletedProgress(
+        final NoCompletedProgressException exception
     ) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }

--- a/src/main/java/com/mju/mentoring/mission/exception/exceptions/InvalidChallengerException.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/exceptions/InvalidChallengerException.java
@@ -1,0 +1,8 @@
+package com.mju.mentoring.mission.exception.exceptions;
+
+public class InvalidChallengerException extends RuntimeException {
+
+    public InvalidChallengerException() {
+        super("유효한 도전자가 아닙니다!");
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/exception/exceptions/NoCompletedProgressException.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/exceptions/NoCompletedProgressException.java
@@ -1,0 +1,8 @@
+package com.mju.mentoring.mission.exception.exceptions;
+
+public class NoCompletedProgressException extends RuntimeException {
+
+    public NoCompletedProgressException() {
+        super("받을 수 있는 보상이 없습니다!");
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/exception/exceptions/NotFoundProgressException.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/exceptions/NotFoundProgressException.java
@@ -1,0 +1,8 @@
+package com.mju.mentoring.mission.exception.exceptions;
+
+public class NotFoundProgressException extends RuntimeException {
+
+    public NotFoundProgressException(final Long id) {
+        super("id가 " + id + "인 진행도를 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/exception/exceptions/WrongProgressStatusException.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/exceptions/WrongProgressStatusException.java
@@ -1,0 +1,8 @@
+package com.mju.mentoring.mission.exception.exceptions;
+
+public class WrongProgressStatusException extends RuntimeException {
+
+    public WrongProgressStatusException() {
+        super("잘못된 progress status입니다!");
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/exception/exceptions/WrongRewardStatusException.java
+++ b/src/main/java/com/mju/mentoring/mission/exception/exceptions/WrongRewardStatusException.java
@@ -1,0 +1,8 @@
+package com.mju.mentoring.mission.exception.exceptions;
+
+public class WrongRewardStatusException extends RuntimeException{
+
+    public WrongRewardStatusException() {
+        super("잘못된 reward status입니다!");
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
@@ -44,7 +44,7 @@ public class MissionProgressQueryDslRepository {
             .fetchFirst() != null;
     }
 
-    public List<CurrentProgress> findAll(
+    public List<CurrentProgress> findAll(final Long challengerId,
         final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
         return queryFactory.select(Projections.constructor(
                 CurrentProgress.class,
@@ -56,7 +56,8 @@ public class MissionProgressQueryDslRepository {
             .from(missionProgress)
             .innerJoin(mission)
             .on(missionProgress.missionId.eq(mission.id))
-            .where(sameProgressStatus(progressStatus), sameRewardStatus(rewardStatus))
+            .where(missionProgress.challengerId.eq(challengerId),
+                sameProgressStatus(progressStatus), sameRewardStatus(rewardStatus))
             .fetchJoin()
             .fetch();
     }

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
@@ -2,6 +2,7 @@ package com.mju.mentoring.mission.infrastructure.progress;
 
 import static com.mju.mentoring.mission.domain.mission.QMission.mission;
 import static com.mju.mentoring.mission.domain.progress.QMissionProgress.missionProgress;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.WAITING;
 
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
@@ -57,6 +58,13 @@ public class MissionProgressQueryDslRepository {
             .on(missionProgress.missionId.eq(mission.id))
             .where(sameProgressStatus(progressStatus), sameRewardStatus(rewardStatus))
             .fetchJoin()
+            .fetch();
+    }
+
+    public List<MissionProgress> findRewardWaitingProgress(final Long challengerId) {
+        return queryFactory.selectFrom(missionProgress)
+            .where(missionProgress.challengerId.eq(challengerId),
+                missionProgress.currentInfo.rewardStatus.eq(WAITING))
             .fetch();
     }
 

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
@@ -6,8 +6,11 @@ import static com.mju.mentoring.mission.domain.progress.QMissionProgress.mission
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +43,8 @@ public class MissionProgressQueryDslRepository {
             .fetchFirst() != null;
     }
 
-    public List<CurrentProgress> findAll() {
+    public List<CurrentProgress> findAll(
+        final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
         return queryFactory.select(Projections.constructor(
                 CurrentProgress.class,
                 mission.title,
@@ -51,7 +55,22 @@ public class MissionProgressQueryDslRepository {
             .from(missionProgress)
             .innerJoin(mission)
             .on(missionProgress.missionId.eq(mission.id))
+            .where(sameProgressStatus(progressStatus), sameRewardStatus(rewardStatus))
             .fetchJoin()
             .fetch();
+    }
+
+    private BooleanExpression sameProgressStatus(final ProgressStatus progressStatus) {
+        if (progressStatus == null) {
+            return null;
+        }
+        return missionProgress.currentInfo.progressInfo.progressStatus.eq(progressStatus);
+    }
+
+    private BooleanExpression sameRewardStatus(final RewardStatus rewardStatus) {
+        if (rewardStatus == null) {
+            return null;
+        }
+        return missionProgress.currentInfo.rewardStatus.eq(rewardStatus);
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
@@ -6,7 +6,10 @@ import static com.mju.mentoring.mission.domain.progress.QMissionProgress.mission
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
+import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -35,5 +38,20 @@ public class MissionProgressQueryDslRepository {
                 missionProgress.missionId.eq(missionId)
             )
             .fetchFirst() != null;
+    }
+
+    public List<CurrentProgress> findAll() {
+        return queryFactory.select(Projections.constructor(
+                CurrentProgress.class,
+                mission.title,
+                missionProgress.currentInfo.currentCount,
+                missionProgress.currentInfo.progressInfo.goal,
+                missionProgress.currentInfo.progressInfo.progress
+            ))
+            .from(missionProgress)
+            .innerJoin(mission)
+            .on(missionProgress.missionId.eq(mission.id))
+            .fetchJoin()
+            .fetch();
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepository.java
@@ -51,7 +51,9 @@ public class MissionProgressQueryDslRepository {
                 mission.title,
                 missionProgress.currentInfo.currentCount,
                 missionProgress.currentInfo.progressInfo.goal,
-                missionProgress.currentInfo.progressInfo.progress
+                missionProgress.currentInfo.progressInfo.progress,
+                missionProgress.currentInfo.progressInfo.progressStatus,
+                missionProgress.currentInfo.rewardStatus
             ))
             .from(missionProgress)
             .innerJoin(mission)

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
+import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -14,6 +16,11 @@ public class MissionProgressRepositoryImpl implements MissionProgressRepository 
 
     private final MissionProgressJpaRepository missionProgressJpaRepository;
     private final MissionProgressQueryDslRepository queryDslRepository;
+
+    @Override
+    public List<CurrentProgress> findAll() {
+        return queryDslRepository.findAll();
+    }
 
     @Override
     public Optional<MissionProgress> findById(final Long id) {

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
@@ -20,9 +20,9 @@ public class MissionProgressRepositoryImpl implements MissionProgressRepository 
     private final MissionProgressQueryDslRepository queryDslRepository;
 
     @Override
-    public List<CurrentProgress> findAll(
+    public List<CurrentProgress> findAll(final Long challengerId,
         final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
-        return queryDslRepository.findAll(progressStatus, rewardStatus);
+        return queryDslRepository.findAll(challengerId, progressStatus, rewardStatus);
     }
 
     @Override

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import java.util.List;
 import java.util.Optional;
@@ -18,8 +20,9 @@ public class MissionProgressRepositoryImpl implements MissionProgressRepository 
     private final MissionProgressQueryDslRepository queryDslRepository;
 
     @Override
-    public List<CurrentProgress> findAll() {
-        return queryDslRepository.findAll();
+    public List<CurrentProgress> findAll(
+        final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
+        return queryDslRepository.findAll(progressStatus, rewardStatus);
     }
 
     @Override

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressRepositoryImpl.java
@@ -51,4 +51,9 @@ public class MissionProgressRepositoryImpl implements MissionProgressRepository 
     public boolean hasChallengedMission(final Long challengerId, final Long missionId) {
         return queryDslRepository.hasAlreadyChallengedMission(challengerId, missionId);
     }
+
+    @Override
+    public List<MissionProgress> findRewardWaitingProgress(final Long challengerId) {
+        return queryDslRepository.findRewardWaitingProgress(challengerId);
+    }
 }

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/dto/CurrentProgress.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/dto/CurrentProgress.java
@@ -1,0 +1,10 @@
+package com.mju.mentoring.mission.infrastructure.progress.dto;
+
+import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
+
+public record CurrentProgress(String missionTitle, Long currentCount, Long goal, Double progress) {
+
+    public ProgressResponse toResponse() {
+        return new ProgressResponse(missionTitle, currentCount, goal, progress);
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/infrastructure/progress/dto/CurrentProgress.java
+++ b/src/main/java/com/mju/mentoring/mission/infrastructure/progress/dto/CurrentProgress.java
@@ -1,10 +1,14 @@
 package com.mju.mentoring.mission.infrastructure.progress.dto;
 
 import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
 
-public record CurrentProgress(String missionTitle, Long currentCount, Long goal, Double progress) {
+public record CurrentProgress(String missionTitle, Long currentCount, Long goal, Double progress,
+                              ProgressStatus progressStatus, RewardStatus rewardStatus) {
 
     public ProgressResponse toResponse() {
-        return new ProgressResponse(missionTitle, currentCount, goal, progress);
+        return new ProgressResponse(
+            missionTitle, currentCount, goal, progress, progressStatus, rewardStatus);
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/ui/mission/MissionController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/mission/MissionController.java
@@ -1,4 +1,4 @@
-package com.mju.mentoring.ui.mission;
+package com.mju.mentoring.mission.ui.mission;
 
 import com.mju.mentoring.member.ui.auth.support.AuthInformation;
 import com.mju.mentoring.mission.application.mission.MissionService;

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
@@ -9,6 +9,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +29,18 @@ public class ProgressController {
     ) {
         List<ProgressResponse> response = progressService.findAll(progressStatus, rewardStatus);
         return ResponseEntity.ok(ProgressResponses.of(response));
+    }
+
+    @PostMapping("/{id}")
+    public ResponseEntity<Void> receiveReward(@PathVariable("id") final Long id) {
+        progressService.receiveReward(id);
+        return ResponseEntity.ok()
+            .build();
+    }
+
+    @PostMapping()
+    public ResponseEntity<Void> receiveAll() {
+        return ResponseEntity.ok()
+            .build();
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
@@ -41,7 +41,7 @@ public class ProgressController {
 
     @PostMapping
     public ResponseEntity<Void> receiveAllRewards(@AuthInformation Long challengerId) {
-        progressService.receiveALlRewards(challengerId);
+        progressService.receiveAllRewards(challengerId);
         return ResponseEntity.ok()
             .build();
     }

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
@@ -33,14 +33,15 @@ public class ProgressController {
     }
 
     @PostMapping("/{id}")
-    public ResponseEntity<Void> receiveReward(@PathVariable("id") final Long id) {
-        progressService.receiveReward(id);
+    public ResponseEntity<Void> receiveReward(
+        @AuthInformation final Long challengerId, @PathVariable("id") final Long id) {
+        progressService.receiveReward(challengerId, id);
         return ResponseEntity.ok()
             .build();
     }
 
     @PostMapping
-    public ResponseEntity<Void> receiveAllRewards(@AuthInformation Long challengerId) {
+    public ResponseEntity<Void> receiveAllRewards(@AuthInformation final Long challengerId) {
         progressService.receiveAllRewards(challengerId);
         return ResponseEntity.ok()
             .build();

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
@@ -25,10 +25,11 @@ public class ProgressController {
 
     @GetMapping
     public ResponseEntity<ProgressResponses> findAll(
+        @AuthInformation final Long challengerId,
         @RequestParam(name = "progressStatus", required = false) final ProgressStatus progressStatus,
         @RequestParam(name = "rewardStatus", required = false) final RewardStatus rewardStatus
     ) {
-        List<ProgressResponse> response = progressService.findAll(progressStatus, rewardStatus);
+        List<ProgressResponse> response = progressService.findAll(challengerId, progressStatus, rewardStatus);
         return ResponseEntity.ok(ProgressResponses.of(response));
     }
 

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
@@ -1,13 +1,16 @@
-package com.mju.mentoring.ui.progress;
+package com.mju.mentoring.mission.ui.progress;
 
 import com.mju.mentoring.mission.application.progress.ProgressService;
 import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
-import com.mju.mentoring.ui.progress.dto.ProgressResponses;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
+import com.mju.mentoring.mission.ui.progress.dto.ProgressResponses;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,8 +21,11 @@ public class ProgressController {
     private final ProgressService progressService;
 
     @GetMapping
-    public ResponseEntity<ProgressResponses> findAll() {
-        List<ProgressResponse> response = progressService.findAll();
+    public ResponseEntity<ProgressResponses> findAll(
+        @RequestParam(name = "progressStatus", required = false) final ProgressStatus progressStatus,
+        @RequestParam(name = "rewardStatus", required = false) final RewardStatus rewardStatus
+    ) {
+        List<ProgressResponse> response = progressService.findAll(progressStatus, rewardStatus);
         return ResponseEntity.ok(ProgressResponses.of(response));
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/ProgressController.java
@@ -1,5 +1,6 @@
 package com.mju.mentoring.mission.ui.progress;
 
+import com.mju.mentoring.member.ui.auth.support.AuthInformation;
 import com.mju.mentoring.mission.application.progress.ProgressService;
 import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
 import com.mju.mentoring.mission.domain.progress.ProgressStatus;
@@ -38,8 +39,9 @@ public class ProgressController {
             .build();
     }
 
-    @PostMapping()
-    public ResponseEntity<Void> receiveAll() {
+    @PostMapping
+    public ResponseEntity<Void> receiveAllRewards(@AuthInformation Long challengerId) {
+        progressService.receiveALlRewards(challengerId);
         return ResponseEntity.ok()
             .build();
     }

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/dto/ProgressResponses.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/dto/ProgressResponses.java
@@ -1,4 +1,4 @@
-package com.mju.mentoring.ui.progress.dto;
+package com.mju.mentoring.mission.ui.progress.dto;
 
 import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
 import java.util.List;

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToProgressStatusConverter.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToProgressStatusConverter.java
@@ -1,12 +1,17 @@
 package com.mju.mentoring.mission.ui.progress.helper;
 
 import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.exception.exceptions.WrongProgressStatusException;
 import org.springframework.core.convert.converter.Converter;
 
 public class StringToProgressStatusConverter implements Converter<String, ProgressStatus> {
 
     @Override
     public ProgressStatus convert(final String source) {
+        try {
             return ProgressStatus.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new WrongProgressStatusException();
+        }
     }
 }

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToProgressStatusConverter.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToProgressStatusConverter.java
@@ -1,0 +1,12 @@
+package com.mju.mentoring.mission.ui.progress.helper;
+
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToProgressStatusConverter implements Converter<String, ProgressStatus> {
+
+    @Override
+    public ProgressStatus convert(final String source) {
+            return ProgressStatus.valueOf(source.toUpperCase());
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToRewardStatusConverter.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToRewardStatusConverter.java
@@ -1,0 +1,12 @@
+package com.mju.mentoring.mission.ui.progress.helper;
+
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToRewardStatusConverter implements Converter<String, RewardStatus> {
+
+    @Override
+    public RewardStatus convert(final String source) {
+        return RewardStatus.valueOf(source.toUpperCase());
+    }
+}

--- a/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToRewardStatusConverter.java
+++ b/src/main/java/com/mju/mentoring/mission/ui/progress/helper/StringToRewardStatusConverter.java
@@ -1,12 +1,17 @@
 package com.mju.mentoring.mission.ui.progress.helper;
 
 import com.mju.mentoring.mission.domain.progress.RewardStatus;
+import com.mju.mentoring.mission.exception.exceptions.WrongRewardStatusException;
 import org.springframework.core.convert.converter.Converter;
 
 public class StringToRewardStatusConverter implements Converter<String, RewardStatus> {
 
     @Override
     public RewardStatus convert(final String source) {
-        return RewardStatus.valueOf(source.toUpperCase());
+        try {
+            return RewardStatus.valueOf(source.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new WrongRewardStatusException();
+        }
     }
 }

--- a/src/main/java/com/mju/mentoring/ui/progress/ProgressController.java
+++ b/src/main/java/com/mju/mentoring/ui/progress/ProgressController.java
@@ -1,0 +1,25 @@
+package com.mju.mentoring.ui.progress;
+
+import com.mju.mentoring.mission.application.progress.ProgressService;
+import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
+import com.mju.mentoring.ui.progress.dto.ProgressResponses;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/progress")
+public class ProgressController {
+
+    private final ProgressService progressService;
+
+    @GetMapping
+    public ResponseEntity<ProgressResponses> findAll() {
+        List<ProgressResponse> response = progressService.findAll();
+        return ResponseEntity.ok(ProgressResponses.of(response));
+    }
+}

--- a/src/main/java/com/mju/mentoring/ui/progress/dto/ProgressResponses.java
+++ b/src/main/java/com/mju/mentoring/ui/progress/dto/ProgressResponses.java
@@ -1,0 +1,11 @@
+package com.mju.mentoring.ui.progress.dto;
+
+import com.mju.mentoring.mission.application.progress.dto.ProgressResponse;
+import java.util.List;
+
+public record ProgressResponses(List<ProgressResponse> progress) {
+
+    public static ProgressResponses of(final List<ProgressResponse> response) {
+        return new ProgressResponses(response);
+    }
+}

--- a/src/test/java/com/mju/mentoring/global/BaseControllerWebMvcTest.java
+++ b/src/test/java/com/mju/mentoring/global/BaseControllerWebMvcTest.java
@@ -7,6 +7,8 @@ import com.mju.mentoring.member.application.member.MemberService;
 import com.mju.mentoring.member.domain.TokenManager;
 import com.mju.mentoring.member.ui.auth.AuthController;
 import com.mju.mentoring.member.ui.member.MemberController;
+import com.mju.mentoring.mission.application.progress.ProgressService;
+import com.mju.mentoring.mission.ui.progress.ProgressController;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -17,7 +19,8 @@ import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
 @MockBean(JpaMetamodelMappingContext.class)
-@WebMvcTest({BoardController.class, AuthController.class, MemberController.class})
+@WebMvcTest({BoardController.class, AuthController.class,
+    MemberController.class, ProgressController.class})
 @AutoConfigureRestDocs
 public abstract class BaseControllerWebMvcTest {
 
@@ -32,4 +35,7 @@ public abstract class BaseControllerWebMvcTest {
 
     @MockBean
     protected MemberService memberService;
+
+    @MockBean
+    protected ProgressService progressService;
 }

--- a/src/test/java/com/mju/mentoring/member/domain/MemberTest.java
+++ b/src/test/java/com/mju/mentoring/member/domain/MemberTest.java
@@ -1,0 +1,22 @@
+package com.mju.mentoring.member.domain;
+
+import static com.mju.mentoring.member.fixture.MemberFixture.id_없는_멤버_생성;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    void 포인트_증가_테스트() {
+        // given
+        Member member = id_없는_멤버_생성();
+
+        // when
+        member.increasePoint(1000L);
+
+        // then
+        assertThat(member.getPoint().getPoint()).isEqualTo(1000L);
+    }
+
+}

--- a/src/test/java/com/mju/mentoring/member/fake/FakeMemberRepository.java
+++ b/src/test/java/com/mju/mentoring/member/fake/FakeMemberRepository.java
@@ -2,6 +2,7 @@ package com.mju.mentoring.member.fake;
 
 import com.mju.mentoring.member.domain.Member;
 import com.mju.mentoring.member.domain.MemberRepository;
+import com.mju.mentoring.member.domain.Point;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -17,6 +18,7 @@ public class FakeMemberRepository implements MemberRepository {
             .id(id++)
             .nickname(member.getNickname())
             .authInformation(member.getAuthInformation())
+            .point(Point.createDefault())
             .build());
     }
 

--- a/src/test/java/com/mju/mentoring/member/fixture/MemberFixture.java
+++ b/src/test/java/com/mju/mentoring/member/fixture/MemberFixture.java
@@ -11,7 +11,7 @@ public class MemberFixture {
     private static final Long DEFAULT_ID = 1L;
 
     public static Member id_없는_멤버_생성() {
-        return Member.of(MEMBER_DEFAULT_USERNAME, MEMBER_DEFAULT_PASSWORD, MEMBER_DEFAULT_NICKNAME);
+        return Member.createDefault(MEMBER_DEFAULT_USERNAME, MEMBER_DEFAULT_PASSWORD, MEMBER_DEFAULT_NICKNAME);
     }
 
     public static Member 멤버_생성() {

--- a/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
+++ b/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
@@ -1,11 +1,16 @@
 package com.mju.mentoring.mission.application.progress;
 
+import static com.mju.mentoring.mission.fixture.ProgressFixture.id_없는_보상_수령_가능한_진행도_생성;
+import static com.mju.mentoring.mission.fixture.ProgressFixture.id_없는_진행중인_진행도_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
+import com.mju.mentoring.mission.exception.exceptions.CannotReceiveRewardException;
 import com.mju.mentoring.mission.fake.FakeMissionProgressRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 class ProgressServiceTest {
 
+    private static final Long FIRST_PROGRESS_ID = 1L;
     private static final Long DEFAULT_CHALLENGER_ID = 1L;
     private static final Long DEFAULT_MISSION_ID = 1L;
     private static final Long DEFAULT_REWARD = 1000L;
@@ -29,8 +35,6 @@ class ProgressServiceTest {
 
     @Test
     void 미션_신청_테스트() {
-        // given
-
         // when
         progressService.challengeMission(DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_REWARD,
             DEFAULT_GOAL);
@@ -51,5 +55,34 @@ class ProgressServiceTest {
             () -> progressService.challengeMission(
                 DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_GOAL))
             .isInstanceOf(AlreadyChallengeMission.class);
+    }
+
+    @Test
+    void 보상_수령_테스트() {
+        // given
+        missionProgressRepository.save(id_없는_보상_수령_가능한_진행도_생성());
+
+        // when
+        progressService.receiveReward(FIRST_PROGRESS_ID);
+
+        // then
+        Optional<MissionProgress> progress = missionProgressRepository.findById(FIRST_PROGRESS_ID);
+        assertSoftly(softly -> {
+            softly.assertThat(progress).isNotEmpty();
+            softly.assertThat(progress.get()
+                .getCurrentInfo().getRewardStatus()).isEqualTo(
+                RewardStatus.RECEIVED);
+        });
+    }
+
+    @Test
+    void 보상_수령_불가_예외_테스트() {
+        // given
+        missionProgressRepository.save(id_없는_진행중인_진행도_생성());
+
+        // when & then
+        assertThatThrownBy(
+            () -> progressService.receiveReward(FIRST_PROGRESS_ID))
+            .isInstanceOf(CannotReceiveRewardException.class);
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
+++ b/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
@@ -2,10 +2,7 @@ package com.mju.mentoring.mission.application.progress;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.mju.mentoring.global.domain.OperateType;
-import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
@@ -18,8 +15,7 @@ class ProgressServiceTest {
 
     private static final Long DEFAULT_CHALLENGER_ID = 1L;
     private static final Long DEFAULT_MISSION_ID = 1L;
-    private static final OperateType DEFAULT_OPERATE_TYPE = OperateType.CREATE;
-    private static final ResourceType DEFAULT_RESOURCE_TYPE = ResourceType.BOARD;
+    private static final Long DEFAULT_REWARD = 1000L;
     private static final Long DEFAULT_GOAL = 5L;
 
     private ProgressService progressService;
@@ -36,7 +32,8 @@ class ProgressServiceTest {
         // given
 
         // when
-        progressService.challengeMission(DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_GOAL);
+        progressService.challengeMission(DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_REWARD,
+            DEFAULT_GOAL);
         Optional<MissionProgress> progress = missionProgressRepository.findById(1L);
 
         // then
@@ -46,40 +43,13 @@ class ProgressServiceTest {
     @Test
     void 이미_신청_중인_미션_예외_테스트() {
         // given
-        progressService.challengeMission(DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_GOAL);
+        progressService.challengeMission(
+            DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_GOAL);
 
         // when & then
         assertThatThrownBy(
             () -> progressService.challengeMission(
-                DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_GOAL))
+                DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_GOAL))
             .isInstanceOf(AlreadyChallengeMission.class);
     }
-
-//    @Test
-//    void 진행도_증가_테스트() {
-//        // given
-//        progressService.challengeMission(DEFAULT_CHALLENGER_ID, DEFAULT_MISSION_ID, DEFAULT_GOAL);
-//
-//        // when
-//        progressService.increaseTargetProgress(
-//            DEFAULT_CHALLENGER_ID, DEFAULT_OPERATE_TYPE, DEFAULT_RESOURCE_TYPE);
-//        Optional<MissionProgress> progress = progressRepository.findByMissionIdAndChallengerId(
-//            DEFAULT_MISSION_ID, DEFAULT_CHALLENGER_ID);
-//
-//        // then
-//        assertSoftly(softly -> {
-//            softly.assertThat(progress).isNotEmpty();
-//            testProgressIncrease(progress);
-//        });
-//    }
-
-    private void testProgressIncrease(final Optional<MissionProgress> progress) {
-        MissionProgress target = progress.get();
-        assertSoftly(softly -> {
-            softly.assertThat(target.getCurrentInfo().getCurrentCount()).isEqualTo(1L);
-            softly.assertThat(target.getCurrentInfo().getProgressInfo().getProgress())
-                .isEqualTo(20);
-        });
-    }
-
 }

--- a/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
+++ b/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
@@ -11,6 +11,7 @@ import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
 import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
 import com.mju.mentoring.mission.exception.exceptions.CannotReceiveRewardException;
+import com.mju.mentoring.mission.exception.exceptions.NoCompletedProgressException;
 import com.mju.mentoring.mission.fake.FakeMissionProgressRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,5 +85,12 @@ class ProgressServiceTest {
         assertThatThrownBy(
             () -> progressService.receiveReward(FIRST_PROGRESS_ID))
             .isInstanceOf(CannotReceiveRewardException.class);
+    }
+
+    @Test
+    void 전체_보상_수령_예외_테스트() {
+        // when & then
+        assertThatThrownBy(() -> progressService.receiveAllRewards(DEFAULT_CHALLENGER_ID))
+            .isInstanceOf(NoCompletedProgressException.class);
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
+++ b/src/test/java/com/mju/mentoring/mission/application/progress/ProgressServiceTest.java
@@ -11,6 +11,7 @@ import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
 import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.exception.exceptions.AlreadyChallengeMission;
 import com.mju.mentoring.mission.exception.exceptions.CannotReceiveRewardException;
+import com.mju.mentoring.mission.exception.exceptions.InvalidChallengerException;
 import com.mju.mentoring.mission.exception.exceptions.NoCompletedProgressException;
 import com.mju.mentoring.mission.fake.FakeMissionProgressRepository;
 import java.util.Optional;
@@ -64,7 +65,7 @@ class ProgressServiceTest {
         missionProgressRepository.save(id_없는_보상_수령_가능한_진행도_생성());
 
         // when
-        progressService.receiveReward(FIRST_PROGRESS_ID);
+        progressService.receiveReward(DEFAULT_CHALLENGER_ID, FIRST_PROGRESS_ID);
 
         // then
         Optional<MissionProgress> progress = missionProgressRepository.findById(FIRST_PROGRESS_ID);
@@ -83,8 +84,19 @@ class ProgressServiceTest {
 
         // when & then
         assertThatThrownBy(
-            () -> progressService.receiveReward(FIRST_PROGRESS_ID))
+            () -> progressService.receiveReward(DEFAULT_CHALLENGER_ID, FIRST_PROGRESS_ID))
             .isInstanceOf(CannotReceiveRewardException.class);
+    }
+
+    @Test
+    void 잘못된_도전자_보상_수령_예외_테스트() {
+        // given
+        missionProgressRepository.save(id_없는_보상_수령_가능한_진행도_생성());
+
+        // when & then
+        assertThatThrownBy(
+            () -> progressService.receiveReward(2L, FIRST_PROGRESS_ID))
+            .isInstanceOf(InvalidChallengerException.class);
     }
 
     @Test

--- a/src/test/java/com/mju/mentoring/mission/domain/MissionProgressTest.java
+++ b/src/test/java/com/mju/mentoring/mission/domain/MissionProgressTest.java
@@ -15,6 +15,7 @@ class MissionProgressTest {
     private static final Long DEFAULT_GOAL = 5L;
     private static final Long DEFAULT_MISSION_ID = 1L;
     private static final Long DEFAULT_CHALLENGER_ID = 1L;
+    private static final Long DEFAULT_REWARD = 1000L;
 
 
     @Test
@@ -99,6 +100,7 @@ class MissionProgressTest {
     }
 
     private static MissionProgress createDefaultProgress() {
-        return MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_CHALLENGER_ID);
+        return MissionProgress.of(
+            DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_CHALLENGER_ID);
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
+++ b/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
@@ -4,6 +4,8 @@ import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
 import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +18,8 @@ public class FakeMissionProgressRepository implements MissionProgressRepository 
     private Long id = 1L;
 
     @Override
-    public List<CurrentProgress> findAll() {
+    public List<CurrentProgress> findAll(final ProgressStatus progressStatus,
+        final RewardStatus rewardStatus) {
         return null;
     }
 
@@ -62,6 +65,6 @@ public class FakeMissionProgressRepository implements MissionProgressRepository 
             .map(key -> db.get(key))
             .anyMatch(
                 progress -> progress.getMissionId().equals(missionId)
-                        && progress.getChallengerId().equals(challengerId));
+                    && progress.getChallengerId().equals(challengerId));
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
+++ b/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
@@ -1,5 +1,7 @@
 package com.mju.mentoring.mission.fake;
 
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.WAITING;
+
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
@@ -66,5 +68,15 @@ public class FakeMissionProgressRepository implements MissionProgressRepository 
             .anyMatch(
                 progress -> progress.getMissionId().equals(missionId)
                     && progress.getChallengerId().equals(challengerId));
+    }
+
+    @Override
+    public List<MissionProgress> findRewardWaitingProgress(final Long challengerId) {
+        return db.keySet().stream()
+            .map(key -> db.get(key))
+            .filter(progress ->
+                progress.getCurrentInfo().getRewardStatus().equals(WAITING)
+            )
+            .toList();
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
+++ b/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
@@ -4,7 +4,9 @@ import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.domain.progress.MissionProgressRepository;
+import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -12,6 +14,11 @@ public class FakeMissionProgressRepository implements MissionProgressRepository 
 
     private Map<Long, MissionProgress> db = new HashMap<>();
     private Long id = 1L;
+
+    @Override
+    public List<CurrentProgress> findAll() {
+        return null;
+    }
 
     @Override
     public Optional<MissionProgress> findById(final Long id) {

--- a/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
+++ b/src/test/java/com/mju/mentoring/mission/fake/FakeMissionProgressRepository.java
@@ -20,8 +20,8 @@ public class FakeMissionProgressRepository implements MissionProgressRepository 
     private Long id = 1L;
 
     @Override
-    public List<CurrentProgress> findAll(final ProgressStatus progressStatus,
-        final RewardStatus rewardStatus) {
+    public List<CurrentProgress> findAll( final Long challengerId,
+        final ProgressStatus progressStatus, final RewardStatus rewardStatus) {
         return null;
     }
 

--- a/src/test/java/com/mju/mentoring/mission/fixture/ProgressFixture.java
+++ b/src/test/java/com/mju/mentoring/mission/fixture/ProgressFixture.java
@@ -2,6 +2,7 @@ package com.mju.mentoring.mission.fixture;
 
 import static com.mju.mentoring.mission.domain.progress.ProgressStatus.COMPLETED;
 import static com.mju.mentoring.mission.domain.progress.ProgressStatus.IN_PROGRESS;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.NOT_AVAILABLE;
 import static com.mju.mentoring.mission.domain.progress.RewardStatus.RECEIVED;
 import static com.mju.mentoring.mission.domain.progress.RewardStatus.WAITING;
 
@@ -28,6 +29,7 @@ public class ProgressFixture {
             .challengerId(1L)
             .missionId(1L)
             .currentInfo(CurrentInfo.builder()
+                .rewardStatus(NOT_AVAILABLE)
                 .progressInfo(ProgressInfo.builder()
                     .progressStatus(IN_PROGRESS)
                     .build())
@@ -41,6 +43,9 @@ public class ProgressFixture {
             .missionId(1L)
             .currentInfo(CurrentInfo.builder()
                 .rewardStatus(WAITING)
+                .progressInfo(ProgressInfo.builder()
+                    .progressStatus(COMPLETED)
+                    .build())
                 .build())
             .build();
     }

--- a/src/test/java/com/mju/mentoring/mission/fixture/ProgressFixture.java
+++ b/src/test/java/com/mju/mentoring/mission/fixture/ProgressFixture.java
@@ -1,0 +1,57 @@
+package com.mju.mentoring.mission.fixture;
+
+import static com.mju.mentoring.mission.domain.progress.ProgressStatus.COMPLETED;
+import static com.mju.mentoring.mission.domain.progress.ProgressStatus.IN_PROGRESS;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.RECEIVED;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.WAITING;
+
+import com.mju.mentoring.mission.domain.progress.CurrentInfo;
+import com.mju.mentoring.mission.domain.progress.MissionProgress;
+import com.mju.mentoring.mission.domain.progress.ProgressInfo;
+
+public class ProgressFixture {
+
+    public static MissionProgress id_없는_완료된_진행도_생성() {
+        return MissionProgress.builder()
+            .challengerId(1L)
+            .missionId(1L)
+            .currentInfo(CurrentInfo.builder()
+                .progressInfo(ProgressInfo.builder()
+                    .progressStatus(COMPLETED)
+                    .build())
+                .build())
+            .build();
+    }
+
+    public static MissionProgress id_없는_진행중인_진행도_생성() {
+        return MissionProgress.builder()
+            .challengerId(1L)
+            .missionId(1L)
+            .currentInfo(CurrentInfo.builder()
+                .progressInfo(ProgressInfo.builder()
+                    .progressStatus(IN_PROGRESS)
+                    .build())
+                .build())
+            .build();
+    }
+
+    public static MissionProgress id_없는_보상_수령_가능한_진행도_생성() {
+        return MissionProgress.builder()
+            .challengerId(1L)
+            .missionId(1L)
+            .currentInfo(CurrentInfo.builder()
+                .rewardStatus(WAITING)
+                .build())
+            .build();
+    }
+
+    public static MissionProgress id_없는_보상_수령한_진행도_생성() {
+        return MissionProgress.builder()
+            .challengerId(1L)
+            .missionId(1L)
+            .currentInfo(CurrentInfo.builder()
+                .rewardStatus(RECEIVED)
+                .build())
+            .build();
+    }
+}

--- a/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressJpaRepositoryTest.java
+++ b/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressJpaRepositoryTest.java
@@ -16,6 +16,7 @@ class MissionProgressJpaRepositoryTest {
     private static final Long DEFAULT_GOAL = 1L;
     private static final Long DEFAULT_MISSION_ID = 1L;
     private static final Long DEFAULT_CHALLENGE_ID = 1L;
+    private static final Long DEFAULT_REWARD = 1000L;
 
     @Autowired
     private MissionProgressJpaRepository missionProgressJpaRepository;
@@ -24,7 +25,7 @@ class MissionProgressJpaRepositoryTest {
     void 미션_id와_도전자_id로_진행도_조회_테스트() {
         // given
         missionProgressJpaRepository.save(
-            MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_CHALLENGE_ID));
+            MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_CHALLENGE_ID));
 
         // when
         Optional<MissionProgress> progress = missionProgressJpaRepository.findByMissionIdAndChallengerId(

--- a/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
+++ b/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
@@ -156,4 +156,26 @@ class MissionProgressQueryDslRepositoryTest {
         // then
         assertThat(progress.isEmpty()).isFalse();
     }
+
+    @Test
+    void 보상_수령_가능한_모든_보상_수령_테스트() {
+        // given
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_보상_수령_가능한_진행도_생성());
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_보상_수령_가능한_진행도_생성());
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_진행중인_진행도_생성());
+
+        // when
+        List<MissionProgress> waitingProgress = queryDslRepository.findRewardWaitingProgress(
+            DEFAULT_CHALLENGER_ID);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(waitingProgress.size()).isEqualTo(2);
+            softly.assertThat(waitingProgress.get(0).getId()).isEqualTo(1L);
+            softly.assertThat(waitingProgress.get(1).getId()).isEqualTo(2L);
+        });
+    }
 }

--- a/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
+++ b/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
@@ -99,7 +99,8 @@ class MissionProgressQueryDslRepositoryTest {
             MissionProgress.of(DEFAULT_GOAL, 2L, DEFAULT_REWARD, DEFAULT_CHALLENGER_ID));
 
         // when
-        List<CurrentProgress> progress = queryDslRepository.findAll(null, null);
+        List<CurrentProgress> progress = queryDslRepository.findAll(
+            DEFAULT_CHALLENGER_ID, null, null);
 
         // then
         assertThat(progress.size()).isEqualTo(2);
@@ -112,7 +113,8 @@ class MissionProgressQueryDslRepositoryTest {
         missionProgressJpaRepository.save(id_없는_완료된_진행도_생성());
 
         // when
-        List<CurrentProgress> progress = queryDslRepository.findAll(COMPLETED, null);
+        List<CurrentProgress> progress = queryDslRepository.findAll(
+            DEFAULT_CHALLENGER_ID, COMPLETED, null);
 
         // then
         assertThat(progress.isEmpty()).isFalse();
@@ -125,7 +127,8 @@ class MissionProgressQueryDslRepositoryTest {
         missionProgressJpaRepository.save(id_없는_진행중인_진행도_생성());
 
         // when
-        List<CurrentProgress> progress = queryDslRepository.findAll(IN_PROGRESS, null);
+        List<CurrentProgress> progress = queryDslRepository.findAll(
+            DEFAULT_CHALLENGER_ID, IN_PROGRESS, null);
 
         // then
         assertThat(progress.isEmpty()).isFalse();
@@ -138,7 +141,8 @@ class MissionProgressQueryDslRepositoryTest {
         missionProgressJpaRepository.save(id_없는_보상_수령_가능한_진행도_생성());
 
         // when
-        List<CurrentProgress> progress = queryDslRepository.findAll(null, WAITING);
+        List<CurrentProgress> progress = queryDslRepository.findAll(
+            DEFAULT_CHALLENGER_ID, null, WAITING);
 
         // then
         assertThat(progress.isEmpty()).isFalse();
@@ -151,7 +155,8 @@ class MissionProgressQueryDslRepositoryTest {
         missionProgressJpaRepository.save(id_없는_보상_수령한_진행도_생성());
 
         // when
-        List<CurrentProgress> progress = queryDslRepository.findAll(null, RECEIVED);
+        List<CurrentProgress> progress = queryDslRepository.findAll(
+            DEFAULT_CHALLENGER_ID, null, RECEIVED);
 
         // then
         assertThat(progress.isEmpty()).isFalse();

--- a/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
+++ b/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
@@ -35,6 +35,7 @@ class MissionProgressQueryDslRepositoryTest {
     private final static Long DEFAULT_MISSION_ID = 1L;
     private final static Long DEFAULT_CHALLENGER_ID = 1L;
     private final static Long DEFAULT_GOAL = 5L;
+    private final static Long DEFAULT_REWARD = 1000L;
     private static final ResourceType DEFAULT_RESOURCE_TYPE = ResourceType.BOARD;
     private static final OperateType DEFAULT_OPERATE_TYPE = OperateType.CREATE;
 
@@ -52,7 +53,8 @@ class MissionProgressQueryDslRepositoryTest {
         // given
         missionRepository.save(id_없는_미션_생성());
         missionProgressJpaRepository.save(
-            MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_CHALLENGER_ID));
+            MissionProgress.of(
+                DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_CHALLENGER_ID));
 
         // when
         Optional<MissionProgress> progress = queryDslRepository.findByChallengeIdAndType(
@@ -66,7 +68,8 @@ class MissionProgressQueryDslRepositoryTest {
     void 도전자가_이미_미션을_수행하고_있는지_조회_테스트() {
         // given
         missionProgressJpaRepository.save(
-            MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_CHALLENGER_ID));
+            MissionProgress.of(
+                DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_CHALLENGER_ID));
 
         // when & then
         assertSoftly(softly -> {
@@ -90,9 +93,10 @@ class MissionProgressQueryDslRepositoryTest {
         missionRepository.save(secondMission);
         missionRepository.save(thirdMission);
         missionProgressJpaRepository.save(
-            MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_CHALLENGER_ID));
+            MissionProgress.of(
+                DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_REWARD, DEFAULT_CHALLENGER_ID));
         missionProgressJpaRepository.save(
-            MissionProgress.of(DEFAULT_GOAL, 2L, DEFAULT_CHALLENGER_ID));
+            MissionProgress.of(DEFAULT_GOAL, 2L, DEFAULT_REWARD, DEFAULT_CHALLENGER_ID));
 
         // when
         List<CurrentProgress> progress = queryDslRepository.findAll(null, null);

--- a/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
+++ b/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
@@ -8,8 +8,11 @@ import com.mju.mentoring.global.DatabaseCleaner;
 import com.mju.mentoring.global.config.TestQuerydslConfig;
 import com.mju.mentoring.global.domain.OperateType;
 import com.mju.mentoring.global.domain.ResourceType;
+import com.mju.mentoring.mission.domain.mission.Mission;
 import com.mju.mentoring.mission.domain.progress.MissionProgress;
 import com.mju.mentoring.mission.infrastructure.mission.MissionJpaRepository;
+import com.mju.mentoring.mission.infrastructure.progress.dto.CurrentProgress;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,5 +69,27 @@ class MissionProgressQueryDslRepositoryTest {
                     2L, 2L))
                 .isFalse();
         });
+    }
+
+    @Test
+    void 미션_전체_조회_테스트() {
+        // given
+        Mission firstMission = id_없는_미션_생성();
+        Mission secondMission = id_없는_미션_생성();
+        Mission thirdMission = id_없는_미션_생성();
+
+        missionRepository.save(firstMission);
+        missionRepository.save(secondMission);
+        missionRepository.save(thirdMission);
+        missionProgressJpaRepository.save(
+            MissionProgress.of(DEFAULT_GOAL, DEFAULT_MISSION_ID, DEFAULT_CHALLENGER_ID));
+        missionProgressJpaRepository.save(
+            MissionProgress.of(DEFAULT_GOAL, 2L, DEFAULT_CHALLENGER_ID));
+
+        // when
+        List<CurrentProgress> progress = queryDslRepository.findAll();
+
+        // then
+        assertThat(progress.size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
+++ b/src/test/java/com/mju/mentoring/mission/infrastructure/progress/MissionProgressQueryDslRepositoryTest.java
@@ -1,6 +1,14 @@
 package com.mju.mentoring.mission.infrastructure.progress;
 
+import static com.mju.mentoring.mission.domain.progress.ProgressStatus.COMPLETED;
+import static com.mju.mentoring.mission.domain.progress.ProgressStatus.IN_PROGRESS;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.RECEIVED;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.WAITING;
 import static com.mju.mentoring.mission.fixture.MissionFixture.id_없는_미션_생성;
+import static com.mju.mentoring.mission.fixture.ProgressFixture.id_없는_보상_수령_가능한_진행도_생성;
+import static com.mju.mentoring.mission.fixture.ProgressFixture.id_없는_보상_수령한_진행도_생성;
+import static com.mju.mentoring.mission.fixture.ProgressFixture.id_없는_완료된_진행도_생성;
+import static com.mju.mentoring.mission.fixture.ProgressFixture.id_없는_진행중인_진행도_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -87,9 +95,61 @@ class MissionProgressQueryDslRepositoryTest {
             MissionProgress.of(DEFAULT_GOAL, 2L, DEFAULT_CHALLENGER_ID));
 
         // when
-        List<CurrentProgress> progress = queryDslRepository.findAll();
+        List<CurrentProgress> progress = queryDslRepository.findAll(null, null);
 
         // then
         assertThat(progress.size()).isEqualTo(2);
+    }
+
+    @Test
+    void 완료된_미션_조회_테스트() {
+        // given
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_완료된_진행도_생성());
+
+        // when
+        List<CurrentProgress> progress = queryDslRepository.findAll(COMPLETED, null);
+
+        // then
+        assertThat(progress.isEmpty()).isFalse();
+    }
+
+    @Test
+    void 진행중인_미션_조회_테스트() {
+        // given
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_진행중인_진행도_생성());
+
+        // when
+        List<CurrentProgress> progress = queryDslRepository.findAll(IN_PROGRESS, null);
+
+        // then
+        assertThat(progress.isEmpty()).isFalse();
+    }
+
+    @Test
+    void 보상_수령_가능한_미션_조회_테스트() {
+        // given
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_보상_수령_가능한_진행도_생성());
+
+        // when
+        List<CurrentProgress> progress = queryDslRepository.findAll(null, WAITING);
+
+        // then
+        assertThat(progress.isEmpty()).isFalse();
+    }
+
+    @Test
+    void 보상_수령한_미션_조회_테스트() {
+        // given
+        missionRepository.save(id_없는_미션_생성());
+        missionProgressJpaRepository.save(id_없는_보상_수령한_진행도_생성());
+
+        // when
+        List<CurrentProgress> progress = queryDslRepository.findAll(null, RECEIVED);
+
+        // then
+        assertThat(progress.isEmpty()).isFalse();
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/ui/progress/ProgressControllerMvcTest.java
+++ b/src/test/java/com/mju/mentoring/mission/ui/progress/ProgressControllerMvcTest.java
@@ -18,7 +18,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 public class ProgressControllerMvcTest extends BaseControllerWebMvcTest {
 
@@ -70,12 +69,20 @@ public class ProgressControllerMvcTest extends BaseControllerWebMvcTest {
     }
 
     @Test
-    void enum_변환_실패_테스트() throws Exception {
+    void reward_status_변환_실패_테스트() throws Exception {
         // when & then
         mockMvc.perform(get("/progress?rewardStatus=OTHER")
                 .header(HEADER_NAME, TOKEN_FORMAT)
             )
-            .andExpect(result -> assertThat(result.getResolvedException())
-                .isInstanceOf(MethodArgumentTypeMismatchException.class));
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void progress_status_변환_실패_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(get("/progress?progressStatus=OTHER")
+                .header(HEADER_NAME, TOKEN_FORMAT)
+            )
+            .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/mju/mentoring/mission/ui/progress/ProgressControllerMvcTest.java
+++ b/src/test/java/com/mju/mentoring/mission/ui/progress/ProgressControllerMvcTest.java
@@ -1,0 +1,81 @@
+package com.mju.mentoring.mission.ui.progress;
+
+import static com.mju.mentoring.mission.domain.progress.ProgressStatus.COMPLETED;
+import static com.mju.mentoring.mission.domain.progress.RewardStatus.WAITING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mju.mentoring.global.BaseControllerWebMvcTest;
+import com.mju.mentoring.mission.domain.progress.ProgressStatus;
+import com.mju.mentoring.mission.domain.progress.RewardStatus;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+public class ProgressControllerMvcTest extends BaseControllerWebMvcTest {
+
+    private static final String HEADER_NAME = "Authorization";
+    private static final String TOKEN_FORMAT = "Bearer accessToken...";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Captor
+    ArgumentCaptor<ProgressStatus> progressStatusArgumentCaptor;
+
+    @Captor
+    ArgumentCaptor<RewardStatus> rewardStatusArgumentCaptor;
+
+    @Test
+    void 진행도_전체_조회_미션_상태_테스트() throws Exception {
+        // given
+        given(progressService.findAll(progressStatusArgumentCaptor.capture(), any()))
+            .willReturn(List.of());
+
+        // when
+        mockMvc.perform(get("/progress?progressStatus=COMPLETED")
+                .header(HEADER_NAME, TOKEN_FORMAT)
+            )
+            .andExpect(status().isOk());
+
+        // then
+        assertThat(progressStatusArgumentCaptor.getValue()).isEqualTo(COMPLETED);
+    }
+
+    @Test
+    void 진행도_전체_조회_보상_상태_테스트() throws Exception {
+        // given
+        given(progressService.findAll(any(), rewardStatusArgumentCaptor.capture()))
+            .willReturn(List.of());
+
+        // when
+        mockMvc.perform(get("/progress?rewardStatus=WAITING")
+                .header(HEADER_NAME, TOKEN_FORMAT)
+            )
+            .andExpect(status().isOk());
+
+        // then
+        assertThat(rewardStatusArgumentCaptor.getValue()).isEqualTo(WAITING);
+    }
+
+    @Test
+    void enum_변환_실패_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(get("/progress?rewardStatus=OTHER")
+                .header(HEADER_NAME, TOKEN_FORMAT)
+            )
+            .andExpect(result -> assertThat(result.getResolvedException())
+                .isInstanceOf(MethodArgumentTypeMismatchException.class));
+    }
+}

--- a/src/test/java/com/mju/mentoring/mission/ui/progress/ProgressControllerMvcTest.java
+++ b/src/test/java/com/mju/mentoring/mission/ui/progress/ProgressControllerMvcTest.java
@@ -39,7 +39,8 @@ public class ProgressControllerMvcTest extends BaseControllerWebMvcTest {
     @Test
     void 진행도_전체_조회_미션_상태_테스트() throws Exception {
         // given
-        given(progressService.findAll(progressStatusArgumentCaptor.capture(), any()))
+        given(progressService.findAll(
+            any(), progressStatusArgumentCaptor.capture(), any()))
             .willReturn(List.of());
 
         // when
@@ -55,7 +56,8 @@ public class ProgressControllerMvcTest extends BaseControllerWebMvcTest {
     @Test
     void 진행도_전체_조회_보상_상태_테스트() throws Exception {
         // given
-        given(progressService.findAll(any(), rewardStatusArgumentCaptor.capture()))
+        given(progressService.findAll(
+            any(), any(), rewardStatusArgumentCaptor.capture()))
             .willReturn(List.of());
 
         // when


### PR DESCRIPTION
미션 진행도 조회와 보상 수령 기능 구현했습니다.

미션 진행도 조회는 아래와 같이 필터링이 가능합니다.
- 전체 진행도 조회
- 현재 진행 중인 미션 진행도 조회
- 이미 완료한 미션 진행도 조회
- 보상 수령 가능한 미션 진행도 조회

보상 수령 기능은 특정 미션에 대한 수령과 현재 수령 가능한 모든 보상 수령이 가능합니다.

이번 기능을 구현하면서 몇가지 궁금한 점이 있었습니다..!
미션 진행도를 조회할 때 미션 진행도 엔티티만으로 주고자 하는 정보를 모두 줄 수 없어서 Mission 테이블과 MissionProgress 테이블을 조인해 정보를 조합해야 했습니다. 때문에 infrastructure 영역에서 application 영역으로 넘어가는 dto가 결국 미션 진행도 조회에 대한 응답이 됩니다. 즉 infrastructure 영역 application 영역 ui 영역에서 같은 dto를 공유합니다. 저는 세 영역이 같은 dto를 공유했을 때 유지보수나 확장성면에서 좋지 않을 것이라고 생각해 application 영역과 ui 영역 간 dto를 따로 분리했습니다. 어떤 방법이 더 좋은 방법인지 궁금합니다!

두 번째로 미션 진행도를 필터링할 때 ui 영역에서 Enum으로 요청을 변환하는 과정이 필요했기 때문에 Converter를 만들었는데 더 좋은 방법이 있는지 궁금합니다!

마지막으로 조금 막연할 수 있지만 현재 MissionProgress 도메인이 너무 복잡한지도 궁금합니다..!